### PR TITLE
デバイス名からも選択できるようにする

### DIFF
--- a/python/mmvc_client_CPU.py
+++ b/python/mmvc_client_CPU.py
@@ -457,7 +457,7 @@ class VCPrifile():
 
 def config_get(conf):
     config_path = conf
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         data = f.read()
     config = json.loads(data)
     hparams = VCPrifile(**config)

--- a/python/mmvc_client_CPU.py
+++ b/python/mmvc_client_CPU.py
@@ -15,6 +15,7 @@ import utils
 from models import SynthesizerTrn
 from text.symbols import symbols
 # from Shifter.shifter import Shifter
+import sounddevice as sd
 import soundfile as sf
 #noice reduce
 import noisereduce as nr
@@ -101,9 +102,22 @@ class Hyperparameters():
         Hyperparameters.DELAY_FLAMES = value
 
     def set_profile(self, profile):
-        self.set_input_device_1(profile.device.input_device1)
-        self.set_input_device_2(profile.device.input_device2)
-        self.set_output_device_1(profile.device.output_device)
+        sound_devices = sd.query_devices()
+        if type(profile.device.input_device1) == str:
+            self.set_input_device_1(sound_devices.index(sd.query_devices(profile.device.input_device1, 'input')))
+        else:
+            self.set_input_device_1(profile.device.input_device1)
+        
+        if type(profile.device.input_device2) == str:
+            self.set_input_device_2(sound_devices.index(sd.query_devices(profile.device.input_device2, 'input')))
+        else:
+            self.set_input_device_2(profile.device.input_device2)
+        
+        if type(profile.device.output_device) == str:
+            self.set_output_device_1(sound_devices.index(sd.query_devices(profile.device.output_device, 'output')))
+        else:
+            self.set_output_device_1(profile.device.output_device)
+        
         self.set_config_path(profile.path.json)
         self.set_model_path(profile.path.model)
         self.set_NOISE_FILE(profile.path.noise)

--- a/python/mmvc_client_GPU.py
+++ b/python/mmvc_client_GPU.py
@@ -14,6 +14,7 @@ import utils
 from models import SynthesizerTrn
 from text.symbols import symbols
 # from Shifter.shifter import Shifter
+import sounddevice as sd
 import soundfile as sf
 #noice reduce
 import noisereduce as nr
@@ -98,9 +99,22 @@ class Hyperparameters():
         Hyperparameters.DELAY_FLAMES = value
 
     def set_profile(self, profile):
-        self.set_input_device_1(profile.device.input_device1)
-        self.set_input_device_2(profile.device.input_device2)
-        self.set_output_device_1(profile.device.output_device)
+        sound_devices = sd.query_devices()
+        if type(profile.device.input_device1) == str:
+            self.set_input_device_1(sound_devices.index(sd.query_devices(profile.device.input_device1, 'input')))
+        else:
+            self.set_input_device_1(profile.device.input_device1)
+        
+        if type(profile.device.input_device2) == str:
+            self.set_input_device_2(sound_devices.index(sd.query_devices(profile.device.input_device2, 'input')))
+        else:
+            self.set_input_device_2(profile.device.input_device2)
+        
+        if type(profile.device.output_device) == str:
+            self.set_output_device_1(sound_devices.index(sd.query_devices(profile.device.output_device, 'output')))
+        else:
+            self.set_output_device_1(profile.device.output_device)
+        
         self.set_config_path(profile.path.json)
         self.set_model_path(profile.path.model)
         self.set_NOISE_FILE(profile.path.noise)

--- a/python/mmvc_client_GPU.py
+++ b/python/mmvc_client_GPU.py
@@ -456,7 +456,7 @@ class VCPrifile():
 
 def config_get(conf):
     config_path = conf
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         data = f.read()
     config = json.loads(data)
     hparams = VCPrifile(**config)

--- a/python/monotonic_align/core.c
+++ b/python/monotonic_align/core.c
@@ -5,7 +5,7 @@
     "distutils": {
         "name": "monotonic_align.core",
         "sources": [
-            "d:/code/monotonic_align/core.pyx"
+            "core.pyx"
         ]
     },
     "module_name": "monotonic_align.core"

--- a/python/monotonic_align/setup.py
+++ b/python/monotonic_align/setup.py
@@ -4,6 +4,6 @@ import numpy
 
 setup(
   name = 'monotonic_align',
-  ext_modules = cythonize("d:/code/monotonic_align/core.pyx"),
+  ext_modules = cythonize("core.pyx"),
   include_dirs=[numpy.get_include()]
 )

--- a/python/output_audio_device_list.py
+++ b/python/output_audio_device_list.py
@@ -1,23 +1,28 @@
 # -*- coding: utf-8 -*
 import pyaudio
+from os import linesep
 
 def main():
     audio = pyaudio.PyAudio()
     audio_devices = list()
-    isInOut = ""
-
+    host_apis = list()
+    
+    for api_index in range(audio.get_host_api_count()):
+        host_apis.append(audio.get_host_api_info_by_index(api_index)['name'])
+    
     # 音声デバイス毎のインデックス番号を一覧表示
     for x in range(0, audio.get_device_count()): 
         devices = audio.get_device_info_by_index(x)
-        if devices['maxInputChannels'] > 0:
-            isInOut = isInOut + "入"
-        if devices['maxOutputChannels'] > 0:
-            isInOut = isInOut + "出"
-        isInOut = isInOut + "力："
-        
-        audio_devices.append(isInOut + "Index : " + str(devices['index']) + "  デバイス名 : " + devices['name'] + "\n")
+        device_name = devices['name'] + ", " + host_apis[devices['hostApi']]
+        device_name = device_name.replace(linesep, '')
         
         isInOut = ""
+        if devices['maxInputChannels'] > 0:
+            isInOut += "入"
+        if devices['maxOutputChannels'] > 0:
+            isInOut += "出"
+        
+        audio_devices.append(f"{isInOut}力： Index：{devices['index']} デバイス名：\"{device_name}\"\n")
 
     with open('audio_device_list.txt', 'w', encoding='utf-8') as f:
         f.writelines(audio_devices)

--- a/python/rec_environmental_noise.py
+++ b/python/rec_environmental_noise.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*
 import pyaudio
+import sounddevice as sd
 import wave
 import numpy as np
 import time
@@ -73,6 +74,10 @@ def MakeWavFile():
     
     params = config_get(profile_path)
     print(params.device.input_device1)
+    if type(params.device.input_device1) == str:
+        device_index = sd.query_devices().index(sd.query_devices(params.device.input_device1, 'input'))
+    else:
+        device_index = params.device.input_device1
 
     p = pyaudio.PyAudio()
     stream = p.open(format = pyaudio.paInt16,

--- a/python/rec_environmental_noise.py
+++ b/python/rec_environmental_noise.py
@@ -39,7 +39,7 @@ class VCPrifile():
 
 def config_get(conf):
     config_path = conf
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         data = f.read()
     config = json.loads(data)
     hparams = VCPrifile(**config)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,6 +8,7 @@ phonemizer==2.2.1
 PyAudio==0.2.11
 retry==0.9.2
 scipy==1.7.1
+sounddevice==0.4.4
 SoundFile==0.10.3.post1
 torch==1.9.0+cu111
 tqdm==4.62.1

--- a/python/utils.py
+++ b/python/utils.py
@@ -161,12 +161,12 @@ def get_hparams(init=True):
   config_path = args.config
   config_save_path = os.path.join(model_dir, "config.json")
   if init:
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
       data = f.read()
-    with open(config_save_path, "w") as f:
+    with open(config_save_path, "w", encoding="utf-8") as f:
       f.write(data)
   else:
-    with open(config_save_path, "r") as f:
+    with open(config_save_path, "r", encoding="utf-8") as f:
       data = f.read()
   config = json.loads(data)
 
@@ -185,7 +185,7 @@ def get_hparams(init=True):
 
 def get_hparams_from_dir(model_dir):
   config_save_path = os.path.join(model_dir, "config.json")
-  with open(config_save_path, "r") as f:
+  with open(config_save_path, "r", encoding="utf-8") as f:
     data = f.read()
   config = json.loads(data)
 
@@ -195,7 +195,7 @@ def get_hparams_from_dir(model_dir):
 
 
 def get_hparams_from_file(config_path):
-  with open(config_path, "r") as f:
+  with open(config_path, "r", encoding="utf-8") as f:
     data = f.read()
   config = json.loads(data)
 


### PR DESCRIPTION
「myprofile.json」で以下のような形式でデバイスを設定できるようにします
```
"device": {
    "input_device1":"マイク (High Definition Audio Devi, MME",
    "input_device2":false,
    "output_device":12
  }
```

また、「audio_device_list.txt」の出力を以下のように変更しました
```
入力： Index：0 デバイス名："Microsoft サウンド マッパー - Input, MME"
入力： Index：1 デバイス名："マイク (High Definition Audio Devi, MME"
出力： Index：2 デバイス名："Microsoft サウンド マッパー - Output, MME"
出力： Index：3 デバイス名："ヘッドホン (High Definition Audio De, MME"
```

一部対応していないものもあります（以下の例はサンプリングレート違い）
```
出力： Index：35 デバイス名："Output (NVIDIA High Definition Audio), Windows WDM-KS"
出力： Index：36 デバイス名："Output (NVIDIA High Definition Audio), Windows WDM-KS"
```

動作テスト済み環境
- Windows 11
- Python 3.8.10