### PR TITLE
dispose_conv1d_specs部分の処理を低負荷化

### DIFF
--- a/python/mmvc_client_GPU.py
+++ b/python/mmvc_client_GPU.py
@@ -188,11 +188,8 @@ class Hyperparameters():
             x, x_lengths, spec, spec_lengths, y, y_lengths, sid_src = [x.cuda() for x in data]
 
             sid_target = torch.LongTensor([target_id]).cuda() # 話者IDはJVSの番号を100で割った余りです
-            audio = net_g.cuda().voice_conversion(spec, spec_lengths, sid_src=sid_src, sid_tgt=sid_target)[0][0,0].data.cpu().float().numpy()
+            audio = net_g.cuda().voice_conversion(spec, spec_lengths, sid_src, sid_target, dispose_conv1d_specs)[0][0,0].data.cpu().float().numpy()
 
-        if dispose_conv1d_specs != 0:
-            # 出力されたwavでconv1d paddingの影響受けるところを削る
-            audio = audio[dispose_conv1d_length:-dispose_conv1d_length]
         audio = audio * Hyperparameters.MAX_WAV_VALUE
         audio = audio.astype(np.int16).tobytes()
 

--- a/python/models.py
+++ b/python/models.py
@@ -523,11 +523,14 @@ class SynthesizerTrn(nn.Module):
     o = self.dec((z * y_mask)[:,:,:max_len], g=g)
     return o, attn, y_mask, (z, z_p, m_p, logs_p)
 
-  def voice_conversion(self, y, y_lengths, sid_src, sid_tgt):
+  def voice_conversion(self, y, y_lengths, sid_src, sid_tgt, dispose_conv1d_specs=0):
     assert self.n_speakers > 0, "n_speakers have to be larger than 0."
     g_src = self.emb_g(sid_src).unsqueeze(-1)
     g_tgt = self.emb_g(sid_tgt).unsqueeze(-1)
     z, m_q, logs_q, y_mask = self.enc_q(y, y_lengths, g=g_src)
+    if dispose_conv1d_specs != 0:
+      z = z[:, :, dispose_conv1d_specs:-dispose_conv1d_specs]
+      y_mask = y_mask[:, :, dispose_conv1d_specs:-dispose_conv1d_specs]
     z_p = self.flow(z, y_mask, g=g_src)
     z_hat = self.flow(z_p, y_mask, g=g_tgt, reverse=True)
     o_hat = self.dec(z_hat * y_mask, g=g_tgt)


### PR DESCRIPTION
padding汚染された捨ててしまう部分を、Zを生成した時点で削除してflowとdecに渡さないことで、余計な負荷を低減しました
