### PR TITLE
PCスペック事前確認用プログラムの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ old/
 rt-mmvc_client_CPU/rt-mmvc_client_CPU/*
 rt-mmvc_client_GPU/rt-mmvc_client_GPU/*
 audio_device_list.txt
+device_check.txt
 *.rar
 *.exe
 *.build/

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -19,6 +19,10 @@ onnxruntime-directml = "1.13.1"
 pyinstaller = "*"
 
 [dev-packages]
+PyAudio = "~=0.2"
+py-cpuinfo = "~=9.0"
+psutil = "~=5.9"
+nvgpu = "~=0.9"
 
 [requires]
 python_version = "3.9"

--- a/python/makeexe.ps1
+++ b/python/makeexe.ps1
@@ -1,3 +1,4 @@
 pipenv run pyinstaller mmvc_client.py --add-binary "./.venv/Lib/site-packages/onnxruntime/capi/onnxruntime_providers_shared.dll;./onnxruntime/capi/" --add-binary "./.venv/Lib/site-packages/onnxruntime/capi/DirectML.dll;./onnxruntime/capi/" --collect-data librosa --onedir --icon=mmvc.ico --clean -y
 pipenv run pyinstaller output_audio_device_list.py --onefile
 pipenv run pyinstaller rec_environmental_noise.py --onefile
+pipenv run pyinstaller setup_check.py --onefile

--- a/python/setup_check.py
+++ b/python/setup_check.py
@@ -1,0 +1,113 @@
+import logging
+import platform
+from multiprocessing import freeze_support
+
+# 以下必要な外部ライブラリ
+# pip install --upgrade py-cpuinfo
+# pip install --upgrade psutil
+# pip install --upgrade nvgpu
+
+# Pipfileとpipenvを使用する場合
+# cd pyhon
+# pipenv install --dev
+# pipenv run python setup_check.py
+
+
+# cpuinfo.get_cpu_info()とpyinstallerを組み合わせる場合に必要
+freeze_support()
+
+
+
+# 定数
+MMVC_INFO:        str = "MMVC_Client"
+OUTPUT_FILE_NAME: str = "device_check.txt"
+
+LOWER_LIMIT_MEMORY:     int = 4 * 1024**3 # 4 GiB
+LOWER_LIMIT_GPU_MEMORY: int = 1 * 1024**3 # 1 GiB
+
+ONNX_TEXT: str = "このPCでは、onnxモデルを出力することで動作する可能性があります"
+
+
+
+# ログファイル出力の設定
+logging.basicConfig(
+    filename = OUTPUT_FILE_NAME,
+    filemode = "w",
+    encoding = "utf-8",
+    level = logging.INFO,
+    format = "%(levelname)s%(message)s")
+logging.addLevelName(logging.INFO, "")
+logging.addLevelName(logging.WARNING, "\n[警告]\n")
+logging.addLevelName(logging.ERROR, "\n[エラー]\n")
+
+
+
+# 基本的な情報
+logging.info(f"バージョン: {MMVC_INFO}")
+logging.info(f"Python: {platform.python_version()}")
+logging.info(f"アーキテクチャ: {platform.machine()}")
+logging.info(f"OS: {platform.system()}")
+
+
+
+# CPU関連
+try:
+    from cpuinfo import get_cpu_info
+    
+    cpu_info = get_cpu_info()
+    logging.info(f"CPU: {cpu_info['brand_raw']}")
+
+except ModuleNotFoundError:
+    logging.info(f"CPU: {platform.processor()}")
+    logging.warning("py-cpuinfoライブラリがインストールされていません\n" +
+                    "以下のコマンドを実行して、py-cpuinfoをインストールするとより詳細な情報を得られます\n" +
+                    "pip install --upgrade py-cpuinfo\n")
+
+
+# メモリ
+try:
+    from psutil import virtual_memory
+    memory = virtual_memory().total
+    logging.info(f"メモリ: {round(memory / 1024**3, 0)} GiB")
+
+    if memory < LOWER_LIMIT_MEMORY:
+        logging.error("メモリが不足しています\n" +
+                      "メモリを増設することで動作不良が改善される場合があります\n")
+except ModuleNotFoundError:
+    logging.error("psutilライブラリがインストールされていません\n" +
+                  "以下のコマンドを実行して、psutilをインストールする必要があります\n" +
+                  "pip install --upgrade psutil\n")
+
+
+# GPU
+try:
+    import nvgpu
+    
+    gpu_infos = nvgpu.gpu_info()
+    gpu_memory = 0
+    
+    for gpu_info in gpu_infos:
+        temp_gpt_memory = gpu_info["mem_total"] * 1024**2
+        logging.info(f"GPU {gpu_info['index']} 名称: {gpu_info['type']}")
+        logging.info(f"GPU {gpu_info['index']} メモリ: {round(temp_gpt_memory / 1024**3, 1)} GiB")
+        gpu_memory = max(gpu_info["mem_total"] * 1024**2, gpu_memory)
+    
+    if len(gpu_infos) == 0:
+        logging.warning(f"NvidiaのGPUが存在しません\n{ONNX_TEXT}\n")
+    
+    elif gpu_memory < LOWER_LIMIT_GPU_MEMORY:
+        logging.warning(f"GPUのメモリ量が不足しています\n{ONNX_TEXT}\n")
+
+except ModuleNotFoundError:
+    logging.error("nvgpuライブラリがインストールされていません\n" +
+                  "以下のコマンドを実行して、nvgpuをインストールする必要があります\n" +
+                  "pip install --upgrade nvgpu\n")
+
+except FileNotFoundError:
+    # nvidia-smiパッケージが見つからない場合
+    logging.warning(f"NvidiaのGPUもしくはGPUドライバーが存在しません\n{ONNX_TEXT}\n")
+
+
+
+logging.info("デバイス情報取得完了")
+print(f"デバイス情報の取得が完了しました。\n{OUTPUT_FILE_NAME} を確認してください。\nこのウィンドウは閉じて問題ありません。")


### PR DESCRIPTION
PCスペックを確認するためのプログラムsetup_check.pyを追加しました
基本的にexeを実行してもらうことを想定しているため、必要ライブラリはPipfileのdevに追加してあります
```
cd python
pipenv install --dev

pipenv run python setup_check.py
or
pipenv run pyinstaller setup_check.py --onefile
```
<br>

現在、警告とエラーは以下の項目で出力します
注：必要なメモリ量は現在低めに指定してあります
- setup_check.pyの実行に必要なライブラリが欠けている場合
- メモリ量が4GiB未満の場合
- Nvidia製GPUの有無
- Nvidia製GPUのメモリ量が1GiB未満の場合
<br>

以下問題のない場合の実行結果 (device_check.txt)
```
バージョン: MMVC Client
Python: 3.9.13
アーキテクチャ: AMD64
OS: Windows
CPU: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
メモリ: 32.0 GiB
GPU 0 名称: NVIDIA GeForce RTX 3090
GPU 0 メモリ: 24.0 GiB
デバイス情報取得完了
```

以下問題のある場合の実行結果 (device_check.txt)
```
バージョン: MMVC_Client
Python: 3.9.13
アーキテクチャ: AMD64
OS: Windows
CPU: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
メモリ: 2.0 GiB

[エラー]
メモリが不足しています
メモリを増設することで動作不良が改善される場合があります

GPU 0 名称: NVIDIA GeForce RTX 3090
GPU 0 メモリ: 24.0 GiB
デバイス情報取得完了
```