### PR TITLE
Fix オーディオデバイス名の文字化け

### DIFF
--- a/python/output_audio_device_list.py
+++ b/python/output_audio_device_list.py
@@ -15,7 +15,7 @@ def main():
         devices = audio.get_device_info_by_index(x)
         try:
             device_name = devices['name'].encode('shift-jis').decode('utf-8')
-        except:
+        except UnicodeDecodeError:
             device_name = devices['name']
         
         device_name = device_name.replace(linesep, '') + ", " + host_apis[devices['hostApi']]

--- a/python/output_audio_device_list.py
+++ b/python/output_audio_device_list.py
@@ -11,10 +11,14 @@ def main():
         host_apis.append(audio.get_host_api_info_by_index(api_index)['name'])
     
     # 音声デバイス毎のインデックス番号を一覧表示
-    for x in range(0, audio.get_device_count()): 
+    for x in range(0, audio.get_device_count()):
         devices = audio.get_device_info_by_index(x)
-        device_name = devices['name'] + ", " + host_apis[devices['hostApi']]
-        device_name = device_name.replace(linesep, '')
+        try:
+            device_name = devices['name'].encode('shift-jis').decode('utf-8')
+        except:
+            device_name = devices['name']
+        
+        device_name = device_name.replace(linesep, '') + ", " + host_apis[devices['hostApi']]
         
         isInOut = ""
         if devices['maxInputChannels'] > 0:


### PR DESCRIPTION
output_audio_device_list.pyを実行した際に一部デバイス名が文字化けしたのでその修正となります

文字化け発生環境
- Windows 11 Pro 22H2
- Python 3.9.13 (WSL2無し)
<br>

実際に発生した文字化け
```
入力： Index：3 デバイス名："繝槭う繧ｯ (NVIDIA Broadcast), MME"
```

改善後
```
入力： Index：3 デバイス名："マイク (NVIDIA Broadcast), MME"
```