### PR TITLE
AdaptiveResidualBlockのforward処理をCPU対応

### DIFF
--- a/python/residual_block.py
+++ b/python/residual_block.py
@@ -247,7 +247,10 @@ class AdaptiveResidualBlock(nn.Module):
             Tensor: Output tensor (B, channels, T).
 
         """
-        batch_index, ch_index = index_initial(x.size(0), self.channels)
+        batch_index, ch_index = index_initial(x.size(0), self.channels, tensor=False)
+        batch_index = torch.tensor(batch_index).to(x.device)
+        ch_index = torch.tensor(ch_index).to(x.device)
+
         for i, dilation in enumerate(self.dilations):
             xt = self.nonlinears[i](x)
             xP, xF = pd_indexing(xt, d, dilation, batch_index, ch_index)


### PR DESCRIPTION
AdaptiveResidualBlockのforward処理を入力テンソルのデバイス上で処理できるように変更。
（≒cudaが使用できる場合に強制的にcudaを使うようになっていた処理を回避）