### PR TITLE
v1.5のonnx対応（f0が固定長の場合だけ）

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -9,13 +9,15 @@ verify_ssl = true
 name = "downloadpytorch"
 
 [packages]
-torch = {version = "==1.8.1+cu111", index = "downloadpytorch"}
+torch = {version = "==1.10.1+cu111", index = "downloadpytorch"}
 noisereduce = "==2.0.0"
-numpy = "==1.21.1"
 scikit-learn = "==1.0.2"
 sounddevice = "==0.4.4"
 SoundFile = "==0.10.3.post1"
-onnxruntime-directml = "1.13.1"
+numpy = "~=1.23"
+protobuf = "~=3.20"
+pyworld = "==0.3.2"
+onnxruntime-directml = "==1.13.1"
 pyinstaller = "*"
 
 [dev-packages]

--- a/python/mmvc_client.py
+++ b/python/mmvc_client.py
@@ -360,6 +360,17 @@ class Hyperparameters():
                         {
                             "specs": spec.numpy(),
                             "lengths": spec_lengths.numpy(),
+    # dummy_sin = torch.rand(1, 1, 8192)
+    # #dummy_d = [torch.rand(1, 1, 512), torch.rand(1, 1, 2048), torch.rand(1, 1, 4096), torch.rand(1, 1, 8192)]
+    # dummy_d0 = torch.rand(1, 1, 512)
+    # dummy_d1 = torch.rand(1, 1, 2048)
+    # dummy_d2 = torch.rand(1, 1, 4096)
+    # dummy_d3 = torch.rand(1, 1, 8192)
+                            "sin": sin.numpy(),
+                            "d0": d[0].numpy(),
+                            "d1": d[1].numpy(),
+                            "d2": d[2].numpy(),
+                            "d3": d[3].numpy(),
                             "sid_src": sid_src.numpy(),
                             "sid_tgt": sid_target.numpy()
                         })[0][0,0]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,10 @@
 noisereduce==2.0.0
-numpy==1.21.1
+numpy==1.23.5
+protobuf==3.20.3
+pyworld==0.3.2
 #PyAudio==0.2.11
 sounddevice==0.4.4
 SoundFile==0.10.3.post1
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.10.1+cu111
+onnxruntime-directml==1.13.1


### PR DESCRIPTION
1.5でコンバートしたONNXでの変換が可能になりますが、f0を固定長にするため
delay_flames: 8192
overlap: 0
dispose_stft_specs: 0
dispose_conv1d_specs: 0
に設定する必要があります。